### PR TITLE
feat: registration nickname now nullable

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,7 +73,7 @@ model Group {
 
 model Registration {
   id          BigInt    @id @default(autoincrement())
-  nickname    String
+  nickname    String?
   authority   Int       @db.TinyInt
   isActivated Boolean
   createdAt   DateTime  @default(now())


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 프리즈마 스키마에서 Registration 테이블의 nickname 칼럼을 nullable로 설정했습니다

## 비고
