### PR TITLE
feat: Auth Exception Type 추가 & Guard 및 currentUser Decorator 로직 추가

### DIFF
--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 
-export const CurrentOauth2User = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+export const CurrentUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const req = ctx.switchToHttp().getRequest();
 
-  return req.body.oauth2Id;
+  return req.user;
 });

--- a/src/common/exceptions/bad-request-exception.ts
+++ b/src/common/exceptions/bad-request-exception.ts
@@ -1,0 +1,32 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+
+export class BadRequestException extends HttpException {
+  constructor(code: AuthExceptionType) {
+    super(types[code], HttpStatus.BAD_REQUEST);
+  }
+}
+
+const types = {
+  AU001: {
+    code: "AU001",
+    message: "Invalid Authorization Code",
+  },
+  AU002: {
+    code: "AU002",
+    message: "No Token in Request Cookie",
+  },
+  AU003: {
+    code: "AU003",
+    message: "Invalid Token (Wrong Format)",
+  },
+  AU004: {
+    code: "AU004",
+    message: "Invalid Token (Wrong ISS)",
+  },
+  AU005: {
+    code: "AU004",
+    message: "Invalid Token (Wrong Signature)",
+  },
+};
+
+type AuthExceptionType = keyof typeof types;

--- a/src/common/exceptions/bad-request-exception.ts
+++ b/src/common/exceptions/bad-request-exception.ts
@@ -17,15 +17,11 @@ const types = {
   },
   AU003: {
     code: "AU003",
-    message: "Invalid Token (Wrong Format)",
+    message: "Expired Token",
   },
   AU004: {
     code: "AU004",
-    message: "Invalid Token (Wrong ISS)",
-  },
-  AU005: {
-    code: "AU004",
-    message: "Invalid Token (Wrong Signature)",
+    message: "Invalid Token",
   },
 };
 

--- a/src/common/exceptions/unauthorized-request.exception.ts
+++ b/src/common/exceptions/unauthorized-request.exception.ts
@@ -7,6 +7,10 @@ export class UnauthorizedException extends HttpException {
 }
 
 const types = {
+  AU005: {
+    code: "AU005",
+    message: "Expired Token",
+  },
   AU006: {
     code: "AU006",
     message: "Not Logged in",

--- a/src/common/exceptions/unauthorized-request.exception.ts
+++ b/src/common/exceptions/unauthorized-request.exception.ts
@@ -1,0 +1,24 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+
+export class UnauthorizedException extends HttpException {
+  constructor(code: AuthExceptionType) {
+    super(types[code], HttpStatus.UNAUTHORIZED);
+  }
+}
+
+const types = {
+  AU006: {
+    code: "AU006",
+    message: "Not Logged in",
+  },
+  AU007: {
+    code: "AU007",
+    message: "Not Signed up",
+  },
+  AU008: {
+    code: "AU008",
+    message: "No Authorization",
+  },
+};
+
+type AuthExceptionType = keyof typeof types;

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get, Query, Res } from "@nestjs/common";
+import { Controller, Get, Query, Res, UseGuards } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { Response } from "express";
 import { ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { ConfigService } from "@nestjs/config";
+import { Oauth2Guard } from "./guards/oauth2.guard";
+import { CurrentUser } from "src/common/decorators/current-user.decorator";
 
 @Controller("auth")
 export class AuthController {
@@ -53,4 +55,12 @@ export class AuthController {
     res.clearCookie("token", { httpOnly: true });
     res.status(302).send();
   }
+
+  // // Test API Code
+  // @Get("test")
+  // @UseGuards(Oauth2Guard({strict : true, isSignUp: true }))
+  // async test(@CurrentUser() user) {
+  //   console.log(user);
+  //   return "hi";
+  // }
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -3,8 +3,6 @@ import { AuthService } from "./auth.service";
 import { Response } from "express";
 import { ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { ConfigService } from "@nestjs/config";
-import { Oauth2Guard } from "./guards/oauth2.guard";
-import { CurrentUser } from "src/common/decorators/current-user.decorator";
 
 @Controller("auth")
 export class AuthController {
@@ -55,12 +53,4 @@ export class AuthController {
     res.clearCookie("token", { httpOnly: true });
     res.status(302).send();
   }
-
-  // // Test API Code
-  // @Get("test")
-  // @UseGuards(Oauth2Guard({strict : true, isSignUp: true }))
-  // async test(@CurrentUser() user) {
-  //   console.log(user);
-  //   return "hi";
-  // }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,8 +1,9 @@
 import { PrismaService } from "./../../config/database/prisma.service";
-import { BadRequestException, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import axios from "axios";
 import * as jwt from "jsonwebtoken";
+import { BadRequestException } from "../../common/exceptions/bad-request-exception";
 
 @Injectable()
 export class AuthService {
@@ -29,7 +30,7 @@ export class AuthService {
 
       return response.data.id_token;
     } catch (error) {
-      throw new BadRequestException("카카오 인가코드 인증에 실패하였습니다");
+      throw new BadRequestException("AU001");
     }
   }
 
@@ -44,7 +45,7 @@ export class AuthService {
       });
       return user;
     } else {
-      throw new BadRequestException("Invalid Token");
+      throw new BadRequestException("AU003");
     }
   }
 }

--- a/src/modules/auth/guards/oauth2.guard.ts
+++ b/src/modules/auth/guards/oauth2.guard.ts
@@ -26,6 +26,7 @@ export const Oauth2Guard = (options?: { strict: boolean; isSignUp?: boolean }): 
       } catch (error) {
         // strict False
         if (!options?.strict) return true;
+        if (error.response.code === "AU003") throw new UnauthorizedException("AU005");
         if (error.response.code === "AU007") throw new UnauthorizedException("AU007");
         else throw new UnauthorizedException("AU006");
       }

--- a/src/modules/auth/guards/oauth2.guard.ts
+++ b/src/modules/auth/guards/oauth2.guard.ts
@@ -1,18 +1,36 @@
-import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { CanActivate, ExecutionContext, Injectable, mixin } from "@nestjs/common";
 import { Oauth2Strategy } from "../strategies/oauth2.strategy";
+import { UnauthorizedException } from "src/common/exceptions/unauthorized-request.exception";
 
-@Injectable()
-export class Oauth2Guard implements CanActivate {
-  constructor(private readonly oauth2Strategy: Oauth2Strategy) {}
-  async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
+// options.strict => 로그인 여부 확인 (특정 API 회원가입 된 유저에게 추가 정보 제공(user 정보 기반))
+// options.isSignUp => 회원가입 API 확인
+export const Oauth2Guard = (options?: { strict: boolean; isSignUp?: boolean }): any => {
+  @Injectable()
+  class Oauth2GuardMixin implements CanActivate {
+    constructor(private readonly oauth2Strategy: Oauth2Strategy) {}
 
-    const oauth2Id = await this.oauth2Strategy.validate(request);
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      try {
+        const request = context.switchToHttp().getRequest();
+        const user: any = await this.oauth2Strategy.validate(request);
 
-    if (!oauth2Id) {
-      throw new UnauthorizedException("User not authenticated");
+        // Logged in But not Signed Up
+        if (!user.id || user.deletedAt) {
+          if (!options.isSignUp) {
+            throw new UnauthorizedException("AU007");
+          }
+        }
+
+        request.user = user;
+        return true;
+      } catch (error) {
+        // strict False
+        if (!options?.strict) return true;
+        if (error.response.code === "AU007") throw new UnauthorizedException("AU007");
+        else throw new UnauthorizedException("AU006");
+      }
     }
-    request.body.oauth2Id = oauth2Id;
-    return true;
   }
-}
+  const guard = mixin(Oauth2GuardMixin);
+  return guard;
+};

--- a/src/modules/auth/strategies/oauth2.strategy.ts
+++ b/src/modules/auth/strategies/oauth2.strategy.ts
@@ -1,5 +1,6 @@
+import { PrismaService } from "./../../../config/database/prisma.service";
 import { Request } from "express";
-import { Inject, Injectable, UnauthorizedException } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-local";
 import { Cache } from "cache-manager";
@@ -7,10 +8,14 @@ import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import * as jwt from "jsonwebtoken";
 import * as jwkToPem from "jwk-to-pem";
 import axios from "axios";
+import { BadRequestException } from "../../../common/exceptions/bad-request-exception";
 
 @Injectable()
 export class Oauth2Strategy extends PassportStrategy(Strategy, "oauth2") {
-  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {
+  constructor(
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly prismaService: PrismaService
+  ) {
     super();
   }
 
@@ -18,11 +23,36 @@ export class Oauth2Strategy extends PassportStrategy(Strategy, "oauth2") {
     const token = req.cookies["token"];
 
     if (!token) {
-      throw new UnauthorizedException("No access token found in cookie!");
+      throw new BadRequestException("AU002");
     }
-    // verify signature about token
 
-    // 1. Get KakaoPublic Keys
+    const oauthId = await this.verifyToken(token);
+
+    if (typeof oauthId === "string") {
+      const user = await this.prismaService.user.findUnique({
+        where: {
+          oauthId: oauthId,
+        },
+      });
+      return user || { oauthId: oauthId };
+    } else {
+      throw new BadRequestException("AU003");
+    }
+  }
+
+  private async verifyToken(token: string) {
+    const decodedToken = jwt.decode(token, { complete: true });
+
+    // 1. Verify ISS
+    try {
+      if (decodedToken.payload["iss"] !== "https://kauth.kakao.com") {
+        throw new BadRequestException("AU004");
+      }
+    } catch (error) {
+      throw new BadRequestException("AU004");
+    }
+
+    // 2. Verify Signature with Public Keys
     let cachedKakaoPublicKeys = await this.cacheManager.get("kakaoPublicKeys");
 
     if (!cachedKakaoPublicKeys) {
@@ -31,29 +61,25 @@ export class Oauth2Strategy extends PassportStrategy(Strategy, "oauth2") {
         cachedKakaoPublicKeys = response.data;
         await this.cacheManager.set("kakaoPublicKeys", cachedKakaoPublicKeys, 86400);
       } catch (error) {
-        throw new Error("Error fetching or caching public keys.");
+        throw new BadRequestException("AU005");
       }
     }
-    // 2. Public Key to Pem to use verify signature
     const kakaoPublicKeys = cachedKakaoPublicKeys["keys"];
-    const decodedToken = jwt.decode(token, { complete: true });
     const tokenkKid = decodedToken.header.kid;
     const matchingPublicKey = kakaoPublicKeys.find((jwk) => jwk.kid === tokenkKid);
 
     if (!matchingPublicKey) {
-      throw new UnauthorizedException("Invalid access token");
+      throw new BadRequestException("AU005");
     }
     const pemPublicKey = jwkToPem(matchingPublicKey);
 
-    // 2. Verify with Public Keys
     try {
       jwt.verify(token, pemPublicKey, {
         algorithms: ["RS256"],
       });
-      const oauth2Id = decodedToken.payload.sub;
-      return oauth2Id;
+      return decodedToken.payload.sub;
     } catch (error) {
-      throw new UnauthorizedException("Invalid access token");
+      throw new BadRequestException("AU005");
     }
   }
 }


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- Exception Type 추가 했습니다 AU001~AU008 다른 API 에서도 사용할 수 있을 꺼 같아 common/exceptions 에 추가했습니다 참고 부탁 드립니다.
- Oauth2Guard 에 parameter 를 추가할 수 있습니다 (strict, isSignUp). strict, isSignUp 각각의 의미는 주석에 달아두었습니다.
- CurrentUser 데코레이터의 반환값이 User | oauthId : string 두 가지로 나옵니다.

## 비고

- auth.controller.ts 에 Test API Code 예시 주석으로 추가해두었습니다. 개발할 때 참고하시면 될 것 같습니다.
- strict : True 인 경우 (isSignUp nullable) CurrentUser 데코레이터 의 반환 타입은 User 입니다.
- isSignUp : True 인 경우는 반환 타입은 User 혹은 { oauthId: String } Object가 가능합니다.
- strict : False 인 경우 반환 타입은 null, User 그리고 { oauthId : String } Object 모두 가능합니다.
```
// Test API Code
@Get("signup")
@UseGuards(Oauth2Guard({strict : true, isSignUp: true }))
async test(@CurrentUser() user) {
  console.log(user);
  return "this is sign up";
}
```
