### PR TITLE
Category와 Tag의 id의 타입을 Int로 변경

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,7 +86,7 @@ model Registration {
 }
 
 model Category {
-  id          BigInt       @id @default(autoincrement())
+  id          Int       @id @default(autoincrement())
   name        String
   Restaurants Restaurant[]
 }
@@ -112,14 +112,14 @@ model Restaurant {
   VoteItems       VoteItem[]
   userId          BigInt
   groupId         BigInt
-  categoryId      BigInt
+  categoryId      Int
   user            User             @relation(fields: [userId], references: [id])
   group           Group            @relation(fields: [groupId], references: [id])
   category        Category         @relation(fields: [categoryId], references: [id])
 }
 
 model Tag {
-  id              BigInt           @id @default(autoincrement())
+  id              Int           @id @default(autoincrement())
   name            String
   RestaurantTagAs RestaurantTagA[]
 }
@@ -130,7 +130,7 @@ model RestaurantTagA {
   updatedAt    DateTime   @default(now()) @updatedAt
   deletedAt    DateTime?
   restaurantId String
-  tagId        BigInt
+  tagId        Int
   restaurant   Restaurant @relation(fields: [restaurantId], references: [id])
   tag          Tag        @relation(fields: [tagId], references: [id])
 }


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- Category와 Tag의 id를 BigInt > Int로 변경하였습니다.

## 비고

- 카테고리와 테그 둘 다 레코드의 수가 한정적인 테이블이어서 편리성과 기능을 위해 Int형을 id로 사용하는 방향으로 수정했습니다.
